### PR TITLE
Update instructions for handling AEP Messaging v5+

### DIFF
--- a/Finish/Luma/AppDelegate.swift
+++ b/Finish/Luma/AppDelegate.swift
@@ -206,15 +206,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Perform the task associated with the action.
         Logger.notifications.info("AppDelegate - userNotificationCenter")
         switch response.actionIdentifier {
-        case "ACCEPT_ACTION":
-            Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: "ACCEPT_ACTION")
+           case "ACCEPT_ACTION":
+                // If using AEP Messaging version 5 or later, remove the following parameters: 
+                // ", applicationOpened: true, customActionId: "ACCEPT_ACTION"" 
+                Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: "ACCEPT_ACTION")
 
-        case "DECLINE_ACTION":
-            Messaging.handleNotificationResponse(response, applicationOpened: false, customActionId: "DECLINE_ACTION")
+            case "DECLINE_ACTION":
+                // If using AEP Messaging version 5 or later, remove the following parameters: 
+                // ", applicationOpened: false, customActionId: "DECLINE_ACTION"" 
+                Messaging.handleNotificationResponse(response, applicationOpened: false, customActionId: "DECLINE_ACTION")
 
-        // Handle other actions…
-        default:
-            Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: nil)
+            // Handle other actions…
+            default:
+                // If using AEP Messaging version 5 or later, remove the following parameters: 
+                // ", applicationOpened: true, customActionId: nil"" 
+                Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: nil)
+            }
         }
 
         let userInfo = response.notification.request.content.userInfo

--- a/Start/Luma/AppDelegate.swift
+++ b/Start/Luma/AppDelegate.swift
@@ -178,16 +178,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Perform the task associated with the action.
         Logger.notifications.info("AppDelegate - userNotificationCenter")
         switch response.actionIdentifier {
-        case "ACCEPT_ACTION":
-            Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: "ACCEPT_ACTION")
-
-        case "DECLINE_ACTION":
-            Messaging.handleNotificationResponse(response, applicationOpened: false, customActionId: "DECLINE_ACTION")
-
-        // Handle other actions…
-        default:
-            Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: nil)
-        }
+            case "ACCEPT_ACTION":
+                // If using AEP Messaging version 5 or later, remove the following parameters: 
+                // ", applicationOpened: true, customActionId: "ACCEPT_ACTION"" 
+                Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: "ACCEPT_ACTION")
+            
+            case "DECLINE_ACTION":
+                // If using AEP Messaging version 5 or later, remove the following parameters: 
+                // ", applicationOpened: false, customActionId: "DECLINE_ACTION"" 
+                Messaging.handleNotificationResponse(response, applicationOpened: false, customActionId: "DECLINE_ACTION")
+            
+            // Handle other actions…
+            default:
+                // If using AEP Messaging version 5 or later, remove the following parameters: 
+                // ", applicationOpened: true, customActionId: nil"" 
+                Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: nil)
+            }
 
         let userInfo = response.notification.request.content.userInfo
         Logger.notifications.info("AppDelegate - userNotificationCenter - userInfo: \(userInfo.description)")


### PR DESCRIPTION
In case of upgrading AEPMessaging to 5+ version, the parameters for the function changed. More information on https://developer.adobe.com/client-sdks/edge/adobe-journey-optimizer/push-notification/ios/api-reference/
