### PR TITLE
Upgrade dependencies to 5.x and migrate deprecated APIs

### DIFF
--- a/Finish/Luma.xcodeproj/project.pbxproj
+++ b/Finish/Luma.xcodeproj/project.pbxproj
@@ -907,72 +907,72 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-assurance-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3C52A7BABA1007881F6 /* XCRemoteSwiftPackageReference "aepsdk-core-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-core-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3C62A7BABDC007881F6 /* XCRemoteSwiftPackageReference "aepsdk-edge-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-edge-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3C92A7BAC11007881F6 /* XCRemoteSwiftPackageReference "aepsdk-edgeidentity-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-edgeidentity-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3CC2A7BAC25007881F6 /* XCRemoteSwiftPackageReference "aepsdk-edgeconsent-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-edgeconsent-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3CF2A7BAC3F007881F6 /* XCRemoteSwiftPackageReference "aepsdk-userprofile-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-userprofile-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3D22A7BAC6A007881F6 /* XCRemoteSwiftPackageReference "aepsdk-places-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-places-ios";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3D52A7BAC82007881F6 /* XCRemoteSwiftPackageReference "aepsdk-messaging-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-messaging-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3D82A7BAC9C007881F6 /* XCRemoteSwiftPackageReference "aepsdk-optimize-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-optimize-ios";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Finish/Luma.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Finish/Luma.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-assurance-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "dc78d1cb42181ae59740eee9e51df6b75a32a5b9"
+        "revision" : "7cae37abe8a878b24aaaddfb10427908ea9ffa0e",
+        "version" : "5.0.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-core-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "3bf920dde9e4f97fa4da8a5204f73f8773fd5953"
+        "revision" : "c3727f6b2a25a8e395ee71d42d1671e12851db84",
+        "version" : "5.4.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-edge-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "9aef3e61587b746a87a5599e8e1068fac87d3325"
+        "revision" : "d0d3e0d74ff8999ab8d6bbd30f921610ee1e6dd1",
+        "version" : "5.0.3"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-edgeconsent-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "87dd0c4995f0a3ec734814eaa863febc00598608"
+        "revision" : "595c1b8f912f69655dbf047d4b3a1a63364d12fe",
+        "version" : "5.0.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-edgeidentity-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "9a03480accb02473829591cb89d7a6de11587a8d"
+        "revision" : "25fab07d344981afc768b99a550c63ed032ae3ad",
+        "version" : "5.0.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-messaging-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "da23275cd7891f6f304670c1cd5dee8d6f421768"
+        "revision" : "5b913c46b0026b25bccd873a4407715280642ee7",
+        "version" : "5.6.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-optimize-ios",
       "state" : {
-        "branch" : "main",
-        "revision" : "ed7219f2d608e8854db6f82ab8bcb5afaab548d7"
+        "revision" : "e48fdf76907c8894d89b6cb3e96cbc0d303bd5a7",
+        "version" : "5.2.1"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-places-ios",
       "state" : {
-        "branch" : "main",
-        "revision" : "4c6b9116d9fe9d622a56471d95fea15c95bd8fac"
+        "revision" : "ccb3b7e4d37351b19a9f3e8d9f92d21c3cc5df58",
+        "version" : "5.0.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-rulesengine-ios.git",
       "state" : {
-        "revision" : "0923ec707340874000e06ad2926c5006ddfbc4c9",
-        "version" : "4.0.0"
+        "revision" : "514d2b3787c545bfa6749ffce5dd3e6f560c9319",
+        "version" : "5.0.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-userprofile-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "873cfdebc1a53702d7d4f373e9b5d8d05d2fe556"
+        "revision" : "8a9d7e9da0e1c1afe19d6c4865bf7dd3abbfdccf",
+        "version" : "5.0.0"
       }
     }
   ],

--- a/Finish/Luma/AppDelegate.swift
+++ b/Finish/Luma/AppDelegate.swift
@@ -205,17 +205,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
         // Perform the task associated with the action.
         Logger.notifications.info("AppDelegate - userNotificationCenter")
-        switch response.actionIdentifier {
-        case "ACCEPT_ACTION":
-            Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: "ACCEPT_ACTION")
-
-        case "DECLINE_ACTION":
-            Messaging.handleNotificationResponse(response, applicationOpened: false, customActionId: "DECLINE_ACTION")
-
-        // Handle other actions…
-        default:
-            Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: nil)
-        }
+        
+        Messaging.handleNotificationResponse(response, urlHandler: { url in
+                /// return `true` if the app is handling the url or `false` if the Adobe SDK should handle it
+                let appHandlesUrl = false
+                return appHandlesUrl
+        }, closure: { pushTrackingStatus in
+            if pushTrackingStatus == .trackingInitiated {
+                // tracking was successful
+                Logger.notifications.info("AppDelegate - handleNotificationResponse closure - tracking successful")
+            } else {
+                // tracking failed, view the status for more information
+                Logger.notifications.info("AppDelegate - handleNotificationResponse closure - tracking failed with status \(pushTrackingStatus.rawValue)")
+            }
+        })
 
         let userInfo = response.notification.request.content.userInfo
         Logger.notifications.info("AppDelegate - userNotificationCenter - userInfo: \(userInfo.description)")

--- a/Finish/Luma/Utils/MobileSDK.swift
+++ b/Finish/Luma/Utils/MobileSDK.swift
@@ -289,7 +289,12 @@ struct MobileSDK {
             let xdmData = ["xdm" : identityMap]
             let decisionScope = DecisionScope(name: location)
             Optimize.clearCachedPropositions()
-            Optimize.updatePropositions(for: [decisionScope], withXdm: xdmData)
+            Optimize.updatePropositions(for: [decisionScope], withXdm: xdmData) { data, error in
+                if let error = error as? AEPOptimizeError {
+                    // handle error
+                    Logger.aepMobileSDK.info("MobileSDK - updatePropositionsAT: encountered error \(error.type ?? "unknown")")
+                }
+            }
         }
     }
     
@@ -305,7 +310,12 @@ struct MobileSDK {
             let xdmData = ["xdm" : identityMap]
             let decisionScope = DecisionScope(activityId: activityId, placementId: placementId, itemCount: UInt(itemCount))
             Optimize.clearCachedPropositions()
-            Optimize.updatePropositions(for: [decisionScope], withXdm: xdmData)
+            Optimize.updatePropositions(for: [decisionScope], withXdm: xdmData) { data, error in
+                if let error = error as? AEPOptimizeError {
+                    // handle error
+                    Logger.aepMobileSDK.info("MobileSDK - updatePropositionsOD: encountered error \(error.type ?? "unknown")")
+                }
+            }
         }
     }
 

--- a/Start/Luma.xcodeproj/project.pbxproj
+++ b/Start/Luma.xcodeproj/project.pbxproj
@@ -730,72 +730,72 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-assurance-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3C52A7BABA1007881F6 /* XCRemoteSwiftPackageReference "aepsdk-core-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-core-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3C62A7BABDC007881F6 /* XCRemoteSwiftPackageReference "aepsdk-edge-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-edge-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3C92A7BAC11007881F6 /* XCRemoteSwiftPackageReference "aepsdk-edgeidentity-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-edgeidentity-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3CC2A7BAC25007881F6 /* XCRemoteSwiftPackageReference "aepsdk-edgeconsent-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-edgeconsent-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3CF2A7BAC3F007881F6 /* XCRemoteSwiftPackageReference "aepsdk-userprofile-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-userprofile-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3D22A7BAC6A007881F6 /* XCRemoteSwiftPackageReference "aepsdk-places-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-places-ios";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3D52A7BAC82007881F6 /* XCRemoteSwiftPackageReference "aepsdk-messaging-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-messaging-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 		8BEEA3D82A7BAC9C007881F6 /* XCRemoteSwiftPackageReference "aepsdk-optimize-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/adobe/aepsdk-optimize-ios";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Start/Luma.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Start/Luma.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-assurance-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "dc78d1cb42181ae59740eee9e51df6b75a32a5b9"
+        "revision" : "7cae37abe8a878b24aaaddfb10427908ea9ffa0e",
+        "version" : "5.0.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-core-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "3bf920dde9e4f97fa4da8a5204f73f8773fd5953"
+        "revision" : "c3727f6b2a25a8e395ee71d42d1671e12851db84",
+        "version" : "5.4.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-edge-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "9aef3e61587b746a87a5599e8e1068fac87d3325"
+        "revision" : "d0d3e0d74ff8999ab8d6bbd30f921610ee1e6dd1",
+        "version" : "5.0.3"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-edgeconsent-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "87dd0c4995f0a3ec734814eaa863febc00598608"
+        "revision" : "595c1b8f912f69655dbf047d4b3a1a63364d12fe",
+        "version" : "5.0.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-edgeidentity-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "9a03480accb02473829591cb89d7a6de11587a8d"
+        "revision" : "25fab07d344981afc768b99a550c63ed032ae3ad",
+        "version" : "5.0.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-messaging-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "da23275cd7891f6f304670c1cd5dee8d6f421768"
+        "revision" : "5b913c46b0026b25bccd873a4407715280642ee7",
+        "version" : "5.6.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-optimize-ios",
       "state" : {
-        "branch" : "main",
-        "revision" : "ed7219f2d608e8854db6f82ab8bcb5afaab548d7"
+        "revision" : "e48fdf76907c8894d89b6cb3e96cbc0d303bd5a7",
+        "version" : "5.2.1"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-places-ios",
       "state" : {
-        "branch" : "main",
-        "revision" : "4c6b9116d9fe9d622a56471d95fea15c95bd8fac"
+        "revision" : "ccb3b7e4d37351b19a9f3e8d9f92d21c3cc5df58",
+        "version" : "5.0.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-rulesengine-ios.git",
       "state" : {
-        "revision" : "0923ec707340874000e06ad2926c5006ddfbc4c9",
-        "version" : "4.0.0"
+        "revision" : "514d2b3787c545bfa6749ffce5dd3e6f560c9319",
+        "version" : "5.0.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adobe/aepsdk-userprofile-ios.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "873cfdebc1a53702d7d4f373e9b5d8d05d2fe556"
+        "revision" : "8a9d7e9da0e1c1afe19d6c4865bf7dd3abbfdccf",
+        "version" : "5.0.0"
       }
     }
   ],

--- a/Start/Luma/AppDelegate.swift
+++ b/Start/Luma/AppDelegate.swift
@@ -177,17 +177,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
         // Perform the task associated with the action.
         Logger.notifications.info("AppDelegate - userNotificationCenter")
-        switch response.actionIdentifier {
-        case "ACCEPT_ACTION":
-            Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: "ACCEPT_ACTION")
-
-        case "DECLINE_ACTION":
-            Messaging.handleNotificationResponse(response, applicationOpened: false, customActionId: "DECLINE_ACTION")
-
-        // Handle other actions…
-        default:
-            Messaging.handleNotificationResponse(response, applicationOpened: true, customActionId: nil)
-        }
+        
+        Messaging.handleNotificationResponse(response, urlHandler: { url in
+                /// return `true` if the app is handling the url or `false` if the Adobe SDK should handle it
+                let appHandlesUrl = false
+                return appHandlesUrl
+        }, closure: { pushTrackingStatus in
+            if pushTrackingStatus == .trackingInitiated {
+                // tracking was successful
+                Logger.notifications.info("AppDelegate - handleNotificationResponse closure - tracking successful")
+            } else {
+                // tracking failed, view the status for more information
+                Logger.notifications.info("AppDelegate - handleNotificationResponse closure - tracking failed with status \(pushTrackingStatus.rawValue)")
+            }
+        })
 
         let userInfo = response.notification.request.content.userInfo
         Logger.notifications.info("AppDelegate - userNotificationCenter - userInfo: \(userInfo.description)")


### PR DESCRIPTION
- Upgrade dependencies to Adobe Experience Platform Mobile SDK 5.x
- Changed package dependencies to use up to next major version rules instead of main branch to avoid breaking changes with major version updates
- Migrated deprecated APIs as per [migration docs](https://developer.adobe.com/client-sdks/resources/migration/ios/migrate-to-5x/#handle-api-migration-and-breaking-changes)